### PR TITLE
Multithreading for Ports Added

### DIFF
--- a/functional/ShellMap.ps1
+++ b/functional/ShellMap.ps1
@@ -6,7 +6,7 @@ $startTime = Get-Date -Format "yyyy-MM-dd HH:mm"
 $timeZone = (Get-TimeZone).StandardName
 Write-Output "Starting ShellMap at $startTime $timeZone"
 
-$baseAddress = "google.com" # UPDATED WITH ARG INPUT
+$baseAddress = "scanme.nmap.org" # UPDATED WITH ARG INPUT (test = scanme.nmap.org)
 $subNet = 0 # ALSO UPDATE WITH ARGS!
 
 # Check if input is a hostname, resolve it to a ip address before continuing:


### PR DESCRIPTION
**Added:**
- Port multithreading
- Top 10 ports services are listed, might want to establish a dictionary later (if port # not found in dictionary mark service as unknown)
- Currently only scans top 5 ports for the listed address, will implement args input when integration begins.

**Need to:**
- Nullify output for errors (connection errors)
- Add multithreading for each ip as well (will then make threads for each port within that)
- Update the SubNet input
- Add filtered, unfiltered checking (still building concept for this)